### PR TITLE
Update ebay_links.py

### DIFF
--- a/ebay_links.py
+++ b/ebay_links.py
@@ -21,3 +21,34 @@ for link in featured_links:
         product_links.append(link.find('a').get('href'))
 
 return product_links
+
+potential_problem = """<script escape-xml="true">
+	  if (typeof(collectionState) != 'object') {
+	      var collectionState = {
+	          itemImageSize: {sWidth: 280, sHeight: 280, lWidth: 580, lHeight: 620},
+	          page: 1,
+	          totalPages: 2,
+	          totalItems: 17,
+	          pageId: '2057253',
+	          currentUser: '',
+	          collectionId: '323101965012',
+	          serviceHost: 'svcs.ebay.com/buying/collections/v1',
+	          owner: 'ebaytecheditor',
+	          csrfToken: '',
+	          localeId: 'en-US',
+	          siteId: 'EBAY-US',
+	          countryId: 'US',
+	          collectionCosEnabled: 'true',
+	          collectionCosHostExternal: 'https://api.ebay.com/social/collection/v1',
+	          collectionCosEditEnabled: 'true',
+	          isCollectionReorderEnabled: 'false',
+	          isOwnerSignedIn: false || false,
+	          partiallySignedInUser: '@@__@@__@@',
+	          baseDomain: 'ebay.com',
+	          currentDomain: 'www.ebay.com',
+	          isTablet: false,
+	          isMobile: false,
+              showViewCount: true
+	      };
+	  }
+	</script>"""


### PR DESCRIPTION
This code scrapes the eBay home page, finds the URLs of each Featured Collection, then goes into each Featured Collection and retrieves the URLs of all the products within each collection (saving it in product_links).

However, the scraper only works partway. Specifically, it only scrapes the first 12 (out of 17) product links, leaving the remaining 5 untouched, even though all 17 links are found within the same HTML tags and attributes. Looking for closely at the page's HTML code (one like this for instance: http://www.ebay.com/cln/ebaytecheditor/Style-That-Clicks/323101965012), the only difference I found is that the first 12 links  and the final 5 are separated by a piece of XML script that I have included at the bottom under the variable potential_problem. Is that code the reason my scraper neglects to scrape the final 5 links?
